### PR TITLE
Submit works e2e: goes full cycle and FormStore.ToObject now works too.

### DIFF
--- a/packages/simplr-forms-core/src/contracts/form-store.ts
+++ b/packages/simplr-forms-core/src/contracts/form-store.ts
@@ -12,3 +12,8 @@ export interface FormStoreState {
 }
 
 export interface FormStoreStateRecord extends TypedRecord<FormStoreStateRecord>, FormStoreState { }
+
+export interface BuiltFormObject {
+    Fields: Immutable.Map<string, FieldStateRecord>;
+    Object: any;
+}

--- a/packages/simplr-forms-dom/src/components/text.tsx
+++ b/packages/simplr-forms-dom/src/components/text.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { FieldProps, FieldValue } from "simplr-forms-core/contracts";
 
 import { BaseDomField, BaseDomFieldState } from "../abstractions/base-dom-field";
-import { OnChangeCallback } from "../contracts/field";
+import { FieldOnChangeCallback } from "../contracts/field";
 
 /**
  * Override the differences between extended interfaces.
@@ -16,7 +16,7 @@ export interface TextProps extends FieldProps, React.HTMLProps<HTMLInputElement>
     name: string;
     onFocus?: React.EventHandler<React.FocusEvent<HTMLInputElement>>;
     onBlur?: React.EventHandler<React.FocusEvent<HTMLInputElement>>;
-    onChange?: OnChangeCallback<HTMLInputElement>;
+    onChange?: FieldOnChangeCallback<HTMLInputElement>;
     ref?: any;
 }
 

--- a/packages/simplr-forms-dom/src/contracts.ts
+++ b/packages/simplr-forms-dom/src/contracts.ts
@@ -1,1 +1,2 @@
 export * from "./contracts/field";
+export * from "./contracts/form";

--- a/packages/simplr-forms-dom/src/contracts/field.ts
+++ b/packages/simplr-forms-dom/src/contracts/field.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { FieldValue } from "simplr-forms-core/contracts";
 
-export interface OnChangeCallback<TElement> extends React.EventHandler<React.FormEvent<TElement>> {
+export interface FieldOnChangeCallback<TElement> extends React.EventHandler<React.FormEvent<TElement>> {
     (event: React.FormEvent<TElement> | undefined, newValue: FieldValue, fieldId: string, formId: string): void;
 }

--- a/packages/simplr-forms-dom/src/contracts/form.ts
+++ b/packages/simplr-forms-dom/src/contracts/form.ts
@@ -2,15 +2,15 @@ import * as React from "react";
 import { FieldValue, FormError } from "simplr-forms-core/contracts";
 import { FormProps as CoreFormProps } from "simplr-forms-core/contracts";
 import { FormStore } from "simplr-forms-core/stores";
-import { OnChangeCallback } from "../contracts/field";
+import { FieldOnChangeCallback } from "../contracts/field";
 
 export interface FormOnSubmitCallback extends React.FormEventHandler<HTMLFormElement> {
     (event: React.FormEvent<HTMLFormElement>, store: FormStore): void | Promise<never> | FormError | string;
 }
 
-export interface FormProps extends CoreFormProps {
+export interface FormProps extends CoreFormProps, React.HTMLProps<HTMLFormElement> {
     onSubmit?: FormOnSubmitCallback;
-    onChange?: OnChangeCallback<any>;
+    onChange?: FieldOnChangeCallback<any>;
     preventSubmitDefaultAndPropagation?: boolean;
     // tslint:disable-next-line:max-line-length
     // More properties at:


### PR DESCRIPTION
SubmiSubmit works e2e: goes full cycle and FormStore.ToObject now works too.
A first e2e path for forms. A small step for forms and a big joy for us, the developers. Yey! 🎉 😄 